### PR TITLE
Bug ved manglende brukerspørsmål

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/lovmefilter/ModelExtensions.kt
+++ b/src/main/kotlin/no/nav/helse/flex/lovmefilter/ModelExtensions.kt
@@ -17,7 +17,7 @@ fun String.tilLovmeSoknadDTO(): LovmeSoknadDTO = objectMapper.readValue(this)
 fun SykepengesoknadDTO.tilLovmeSoknadDTO(): LovmeSoknadDTO {
     // Hent svar på brukerspørsmål om arbeid utenfor Norge. Det skal være bare ett svar spørsmålet, så det
     // første elementet kan brukes hvis det finnes.
-    val sporsmalDTO = this.sporsmal?.first { dto -> dto.tag.equals("ARBEID_UTENFOR_NORGE") }
+    val sporsmalDTO = this.sporsmal?.firstOrNull() { dto -> dto.tag.equals("ARBEID_UTENFOR_NORGE") }
     val arbeidUtenforNorge = when (sporsmalDTO?.svar?.get(0)?.verdi) {
         "JA" -> true
         "NEI" -> false

--- a/src/test/kotlin/no/nav/helse/flex/lovmefilter/LovmeFilterTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/lovmefilter/LovmeFilterTest.kt
@@ -60,6 +60,21 @@ class LovmeFilterTest {
 
         assertThat(lovmeSoknadDTO.arbeidUtenforNorge).isNull()
     }
+
+    @Test
+    fun `Brukerspørsmål om arbeidet i utlandet returnerer NULL hvis spørsmålet ikke finnes`() {
+        val sykepengesoknadDTO = SykepengesoknadDTO(
+            ID,
+            SoknadstypeDTO.ARBEIDSTAKERE,
+            SoknadsstatusDTO.SENDT,
+            FNR,
+            sporsmal = listOf(SporsmalDTO(id = "1", tag = "ANNET", svar = listOf(SvarDTO("NEI"))))
+        )
+
+        val lovmeSoknadDTO = sykepengesoknadDTO.tilLovmeSoknadDTO()
+
+        assertThat(lovmeSoknadDTO.arbeidUtenforNorge).isNull()
+    }
 }
 
 private const val ID = "4d4e41de-5c19-4e2d-b408-b809c37e6cfa"


### PR DESCRIPTION
Denne commiten fikser bug som kaster en exception hvis brukerspørsmål om
arbeid i utlandet ikke finnes når det mappes fra SykepengesoknadDTO til
LovmeSoknadDTO. .first() er erstattet med firstOrNull().

Tilhørende tester er lagt til.