### PR TITLE
Endre navn på topic team

### DIFF
--- a/nais/topics/sykepengesoknad-lovme-filter-topic.yaml
+++ b/nais/topics/sykepengesoknad-lovme-filter-topic.yaml
@@ -21,6 +21,6 @@ spec:
     - team: flex
       application: sykepengesoknad-lovme-filter
       access: write
-    - team: lovme
+    - team: medlemskap
       application: medlemskap-sykepenger-listener
       access: read


### PR DESCRIPTION
Team lovme bruker "medlemskap" som namespace ("team" i topic config), ikke "lovme".