### PR TITLE
Oppdater Spring Boot

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.springframework.boot") version "2.5.5"
+    id("org.springframework.boot") version "2.6.1"
     id("io.spring.dependency-management") version "1.0.11.RELEASE"
     id("org.jlleitschuh.gradle.ktlint") version "10.2.0"
     kotlin("jvm") version "1.6.0"

--- a/src/main/kotlin/no/nav/helse/flex/Application.kt
+++ b/src/main/kotlin/no/nav/helse/flex/Application.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
@@ -16,7 +16,7 @@ fun main(args: Array<String>) {
 }
 
 val objectMapper: ObjectMapper = ObjectMapper().apply {
-    registerModule(KotlinModule())
+    registerKotlinModule()
     registerModule(JavaTimeModule())
     configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)

--- a/src/main/kotlin/no/nav/helse/flex/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/helse/flex/kafka/KafkaConfig.kt
@@ -40,7 +40,7 @@ class KafkaConfig(
     ): ConcurrentKafkaListenerContainerFactory<String, String> {
         val factory = ConcurrentKafkaListenerContainerFactory<String, String>()
         factory.consumerFactory = consumerFactory
-        factory.setErrorHandler(kafkaErrorHandler)
+        factory.setCommonErrorHandler(kafkaErrorHandler)
         factory.containerProperties.ackMode = ContainerProperties.AckMode.MANUAL_IMMEDIATE
         return factory
     }


### PR DESCRIPTION
- Oppdatert spring-boot plugin til 2.6.1.
- Oppdatert KafkaErrorHandler til å arve DefaultErrorHandler i stedet
  for SeekToCurrentErrorHandler som var deprecated.